### PR TITLE
Remove unsupported --disable-log-requests flags from model definitions

### DIFF
--- a/compose/models-deepseek.yml
+++ b/compose/models-deepseek.yml
@@ -26,7 +26,6 @@ services:
       - "16"
       - --trust-remote-code
       - --enforce-eager
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -90,7 +89,6 @@ services:
       - "16"
       - --trust-remote-code
       - --enforce-eager
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -156,7 +154,6 @@ services:
       - "0"
       - --max-model-len
       - "32768"
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -193,4 +190,3 @@ services:
     networks:
       - default
       - vllm_internal
-

--- a/compose/models-experimental.yml
+++ b/compose/models-experimental.yml
@@ -34,7 +34,6 @@ services:
       - --tool-call-parser
       - "hermes"
       - --enforce-eager
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -103,7 +102,6 @@ services:
       - --tool-call-parser
       - "hermes"
       - --enforce-eager
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -371,7 +369,6 @@ services:
       - modelopt_fp4
       - --enforce-eager
       - --trust-remote-code
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -446,7 +443,6 @@ services:
       - "{% for message in messages %}{{'<|' + message['role'] + '|>' + '\n' + message['content'] + '<|end|>\n' }}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>\n' }}{% endif %}"
       - --enforce-eager
       - --trust-remote-code
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -526,7 +522,6 @@ services:
       # - nano_v3
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -621,4 +616,3 @@ services:
   #   networks:
   #     - default
   #     - vllm_internal
-

--- a/compose/models-glm.yml
+++ b/compose/models-glm.yml
@@ -28,7 +28,6 @@ services:
       - compressed-tensors
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -99,7 +98,6 @@ services:
       - compressed-tensors
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -169,7 +167,6 @@ services:
       - compressed-tensors
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -237,7 +234,6 @@ services:
       - --max-num-seqs
       - "8"
       - --trust-remote-code
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface

--- a/compose/models-gpt.yml
+++ b/compose/models-gpt.yml
@@ -40,7 +40,6 @@ services:
       - --load-format
       - fastsafetensors
       - --disable-log-stats
-      - --disable-log-requests
       - --enable-auto-tool-choice
       - --tool-call-parser
       - openai
@@ -136,7 +135,6 @@ services:
       - --load-format
       - fastsafetensors
       - --disable-log-stats
-      - --disable-log-requests
       - --enable-auto-tool-choice
       - --tool-call-parser
       - openai
@@ -190,4 +188,3 @@ services:
     networks:
       - default
       - vllm_internal
-

--- a/compose/models-llama.yml
+++ b/compose/models-llama.yml
@@ -29,7 +29,6 @@ services:
       - modelopt_fp4
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -99,7 +98,6 @@ services:
       - compressed-tensors
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -169,7 +167,6 @@ services:
       - compressed-tensors
       - --kv-cache-dtype
       - fp8
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -209,4 +206,3 @@ services:
     networks:
       - default
       - vllm_internal
-

--- a/compose/models-mistral.yml
+++ b/compose/models-mistral.yml
@@ -445,7 +445,6 @@ services:
       - "16"
       - --max-model-len
       - "128000"
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -481,7 +480,6 @@ services:
     networks:
       - default
       - vllm_internal
-
 
 
 

--- a/compose/models-nemotron.yml
+++ b/compose/models-nemotron.yml
@@ -35,7 +35,6 @@ services:
       - --load-format
       - fastsafetensors
       - --enforce-eager
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface

--- a/compose/models-qwen.yml
+++ b/compose/models-qwen.yml
@@ -31,7 +31,6 @@ services:
       - fp8
       - --max-model-len
       - "131072"
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -93,7 +92,6 @@ services:
       - bfloat16
       - --max-model-len
       - "8192"
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -156,7 +154,6 @@ services:
       - --max-model-len
       - "32768"
       - --trust-remote-code
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -223,7 +220,6 @@ services:
       - --tool-call-parser
       - hermes
       - --enforce-eager
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -288,7 +284,6 @@ services:
       - "16"
       - --max-model-len
       - "32768"
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -347,7 +342,6 @@ services:
       - "3"
       - --max-model-len
       - "4096"
-      - --disable-log-requests
       - --disable-log-stats
    # ports: ["8000:8000"]
     volumes:
@@ -408,7 +402,6 @@ services:
       - fastsafetensors
       - --max-model-len
       - "32768"
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface
@@ -474,7 +467,6 @@ services:
       - --trust-remote-code
       - --quantization
       - modelopt_fp4
-      - --disable-log-requests
       - --disable-log-stats
     volumes:
       - ../vllm_cache_huggingface:/root/.cache/huggingface


### PR DESCRIPTION
Fixes #12.

## What changed
- removed active `--disable-log-requests` flags from compose model definitions that still pass the option to `vllm serve`
- left `--disable-log-stats` unchanged

## Why
The currently used vLLM images reject `--disable-log-requests`, which causes affected model containers to fail startup with:

```text
vllm: error: unrecognized arguments: --disable-log-requests
```

That leaves the gateway reachable but the model upstream unhealthy.

## Validation
- reproduced the crash on `vllm-qwen2.5-1.5b`
- removed the unsupported flag locally
- confirmed the model started successfully and served a `POST /v1/chat/completions` request through the gateway
